### PR TITLE
Improve handling of \k and similar by running keyword pattern regexes inside their respective buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,16 @@ The below source configuration are available.
 
 ### keyword_pattern (type: string)
 
-_Default: [[\%(-\?\d\+\%(\.\d\+\)\?\|\h\w*\%([\-.]\w*\)*\)]]_
+_Default:_ `[[\%(-\?\d\+\%(\.\d\+\)\?\|\h\w*\%([\-.]\w*\)*\)]]`
 
 A vim's regular expression for creating a word list from buffer content.
+
+You can set this to `\k\+` if you want to use the `iskeyword` option for recognizing words.
 
 
 ### get_bufnrs (type: fun(): number[])
 
-_Default: function() return { vim.api.nvim_get_current_buf() } end_
+_Default:_ `function() return { vim.api.nvim_get_current_buf() } end`
 
 A function that specifies the buffer numbers to complete.
 
@@ -51,4 +53,3 @@ get_bufnrs = function()
   return vim.tbl_keys(bufs)
 end
 ```
-

--- a/lua/cmp_buffer/buffer.lua
+++ b/lua/cmp_buffer/buffer.lua
@@ -43,9 +43,11 @@ function buffer.index(self)
     200,
     vim.schedule_wrap(function()
       local chunk = math.min(index + 1000, #lines)
-      for i = index, chunk do
-        self:index_line(i, lines[i] or '')
-      end
+      vim.api.nvim_buf_call(self.bufnr, function()
+        for i = index, chunk do
+          self:index_line(i, lines[i] or '')
+        end
+      end)
       index = chunk + 1
 
       if chunk >= #lines then
@@ -81,11 +83,13 @@ function buffer.watch(self)
 
       -- replace lines
       local lines = vim.api.nvim_buf_get_lines(self.bufnr, firstline, new_lastline, false)
-      for i, line in ipairs(lines) do
-        if line then
-          self:index_line(firstline + i, line or '')
+      vim.api.nvim_buf_call(self.bufnr, function()
+        for i, line in ipairs(lines) do
+          if line then
+            self:index_line(firstline + i, line or '')
+          end
         end
-      end
+      end)
     end),
   })
 end


### PR DESCRIPTION
Basically, regex patterns like `\k` or `\f` depend on buffer-local options (`iskeyword`, `isfname` etc), so there exists the following problem: let's say that I have a `get_bufnrs` function like in README, which returns the currently visible buffers, and start the editor and open two files side-by-side, Lua and Vimscript. I have changed the `iskeyword` option for Vimscript to include `#` because I prefer names of autoloaded functions to be recognized as one word. Now, say I start by editing the Lua file, which invokes this source and causes indexing of buffers for words to start. However, when the Vimscript buffer is indexed, the Lua buffer is the current one, so `\k` there uses Lua's `iskeyword`, which doesn't get me the completion results I expect. Anyway, the solution is to basically switch the current buffer to the correct one when matching regexes during indexing, so that the correct buffer-local options are read.