### PR TITLE
Optimize speed and memory usage on large text files (>1 megabyte)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,55 @@ get_bufnrs = function()
   return vim.tbl_keys(bufs)
 end
 ```
+
+
+### indexing_interval (type: number)
+
+_Default:_ `200`
+
+The rate (in milliseconds) at which buffers are scanned for words when they are first opened.
+Setting this interval to lower values will increase the speed of indexing, but at the expense of
+higher CPU usage. By default indexing happens asynchronously, but setting this option to zero or
+a negative value will switch indexing to a synchronous algorithm, which uses significantly less
+RAM on big files and takes less time in total (to index the entire file), with the obvious
+downside of blocking the user interface for a second or two. On small files (up to tens of
+thousands of lines, probably) the difference will be unnoticeable, though.
+
+
+### indexing_chunk_size (type: number)
+
+_Default:_ `1000`
+
+The number of lines processed in batch every `indexing_interval` milliseconds. Setting it to
+higher values will make indexing faster, but at the cost of responsiveness of the UI. When using
+the synchronous mode, changing this option may improve memory usage, though the default value has
+been tested to be pretty good in this regard.
+
+Please note that the `indexing_interval` and `indexing_chunk_size` are advanced options, change
+them only if you experience performance or RAM usage problems (or need to work on particularly
+large files) and be sure to measure the results!
+
+
+## Performance on large text files
+
+This source has been tested on code files of a few megabytes in size (5-10) and it has been
+optimized for them, however, the indexed words can still take up tens of megabytes of RAM if the
+file is big (on small files it will not be more than a couple of megabytes). So if you wish to
+avoid accidentally wasting lots of RAM when editing big files, you can tweak `get_bufnrs`, for
+example like this:
+
+```lua
+get_bufnrs = function()
+  local buf = vim.api.nvim_get_current_buf()
+  local byte_size = vim.api.nvim_buf_get_offset(buf, vim.api.nvim_buf_line_count(buf))
+  if byte_size > 1024 * 1024 then -- 1 Megabyte max
+    return {}
+  end
+  return { buf }
+end
+```
+
+Of course, this snippet can be combined with any other recipes for `get_bufnrs`.
+
+As another tip, turning on the synchronous indexing mode is very likely to help with reducing
+memory usage, see the `indexing_interval` option.

--- a/lua/cmp_buffer/buffer.lua
+++ b/lua/cmp_buffer/buffer.lua
@@ -145,7 +145,17 @@ function buffer.watch(self)
 
       local delta = new_last_line - old_last_line
       local new_lines_count = self.lines_count + delta
-      if delta > 0 then -- append
+      if new_lines_count == 0 then  -- clear
+        -- This branch protects against bugs after full-file deletion. If you
+        -- do, for example, gdGG, the new_last_line of the event will be zero.
+        -- Which is not true, a buffer always contains at least one empty line,
+        -- only unloaded buffers contain zero lines.
+        new_lines_count = 1
+        for i = self.lines_count, 2, -1 do
+          self.lines_words[i] = nil
+        end
+        self.lines_words[1] = {}
+      elseif delta > 0 then -- append
         -- Explicitly reserve more slots in the array part of the lines table,
         -- all of them will be filled in the next loop, but in reverse order
         -- (which is why I am concerned about preallocation). Why is there no

--- a/lua/cmp_buffer/buffer.lua
+++ b/lua/cmp_buffer/buffer.lua
@@ -1,10 +1,14 @@
 ---@class cmp_buffer.Buffer
 ---@field public bufnr number
----@field public regexes any[]
+---@field public regex any
 ---@field public length number
 ---@field public pattern string
+---@field public indexing_chunk_size number
+---@field public indexing_interval number
 ---@field public timer any|nil
----@field public words table<number, string[]>
+---@field public lines_words table<number, string[]>
+---@field public unique_words table<string, boolean>
+---@field public unique_words_dirty boolean
 ---@field public processing boolean
 local buffer = {}
 
@@ -12,15 +16,22 @@ local buffer = {}
 ---@param bufnr number
 ---@param length number
 ---@param pattern string
+---@param indexing_chunk_size number
+---@param indexing_interval number
 ---@return cmp_buffer.Buffer
-function buffer.new(bufnr, length, pattern)
+function buffer.new(bufnr, length, pattern, indexing_chunk_size, indexing_interval)
   local self = setmetatable({}, { __index = buffer })
   self.bufnr = bufnr
-  self.regexes = {}
+  self.regex = vim.regex(pattern)
   self.length = length
   self.pattern = pattern
+  self.indexing_chunk_size = indexing_chunk_size
+  self.indexing_interval = indexing_interval
   self.timer = nil
-  self.words = {}
+  self.lines_count = 0
+  self.lines_words = {}
+  self.unique_words = {}
+  self.unique_words_dirty = true
   self.processing = false
   return self
 end
@@ -32,28 +43,75 @@ function buffer.close(self)
     self.timer:close()
     self.timer = nil
   end
-  self.words = {}
+  self.lines_count = 0
+  self.lines_words = {}
+  self.unique_words = {}
+  self.unique_words_dirty = false
 end
 
 ---Indexing buffer
 function buffer.index(self)
   self.processing = true
-  local index = 1
-  local lines = vim.api.nvim_buf_get_lines(self.bufnr, 0, -1, false)
+
+  self.lines_count = vim.api.nvim_buf_line_count(self.bufnr)
+  local chunk_max_size = self.indexing_chunk_size
+  if chunk_max_size < 1 then
+    -- Index all lines in one go.
+    chunk_max_size = self.lines_count
+  end
+  local chunk_start = 0
+
+  if self.indexing_interval <= 0 then
+    -- sync algorithm
+
+    vim.api.nvim_buf_call(self.bufnr, function()
+      while chunk_start < self.lines_count do
+        local chunk_end = math.min(chunk_start + chunk_max_size, self.lines_count)
+        -- For some reason requesting line arrays multiple times in chunks
+        -- leads to much better memory usage than doing that in one big array,
+        -- which is why the sync algorithm has better memory usage than the
+        -- async one.
+        local chunk_lines = vim.api.nvim_buf_get_lines(self.bufnr, chunk_start, chunk_end, true)
+        for linenr = chunk_start + 1, chunk_end do
+          self.lines_words[linenr] = {}
+          self:index_line(linenr, chunk_lines[linenr - chunk_start])
+        end
+        chunk_start = chunk_end
+      end
+    end)
+
+    self:rebuild_unique_words()
+
+    self.processing = false
+    return
+  end
+
+  -- async algorithm
+
+  local lines = vim.api.nvim_buf_get_lines(self.bufnr, 0, -1, true)
+  -- This flag prevents vim.schedule() callbacks from piling up in the queue
+  -- when the indexing interval is very short.
+  local scheduled = false
+
   self.timer = vim.loop.new_timer()
-  self.timer:start(
-    0,
-    200,
-    vim.schedule_wrap(function()
-      local chunk = math.min(index + 1000, #lines)
+  self.timer:start(0, self.indexing_interval, function()
+    if scheduled then
+      return
+    end
+    scheduled = true
+    vim.schedule(function()
+      scheduled = false
+
+      local chunk_end = math.min(chunk_start + chunk_max_size, self.lines_count)
       vim.api.nvim_buf_call(self.bufnr, function()
-        for i = index, chunk do
-          self:index_line(i, lines[i] or '')
+        for linenr = chunk_start + 1, chunk_end do
+          self.lines_words[linenr] = {}
+          self:index_line(linenr, lines[linenr])
         end
       end)
-      index = chunk + 1
+      chunk_start = chunk_end
 
-      if chunk >= #lines then
+      if chunk_end >= self.lines_count then
         if self.timer then
           self.timer:stop()
           self.timer:close()
@@ -62,88 +120,127 @@ function buffer.index(self)
         self.processing = false
       end
     end)
-  )
+  end)
 end
+
+-- See below.
+local shared_marker_table_for_preallocation = {}
 
 --- watch
 function buffer.watch(self)
+  -- NOTE: As far as I know, indexing in watching can't be done asynchronously
+  -- because even built-in commands generate multiple consequent `on_lines`
+  -- events, and I'm not even mentioning plugins here. To get accurate results
+  -- we would have to either re-index the entire file on throttled events (slow
+  -- and looses the benefit of on_lines watching), or put the events in a
+  -- queue, which would complicate the plugin a lot. Plus, most changes which
+  -- trigger this event will be from regular editing, and so 99% of the time
+  -- they will affect only 1-2 lines.
   vim.api.nvim_buf_attach(self.bufnr, false, {
-    on_lines = vim.schedule_wrap(function(_, _, _, firstline, old_lastline, new_lastline, _, _, _)
-      if not vim.api.nvim_buf_is_valid(self.bufnr) then
-        self:close()
+    -- NOTE: line indexes are 0-based and the last line is not inclusive.
+    on_lines = function(_, _, _, first_line, old_last_line, new_last_line, _, _, _)
+      if not vim.api.nvim_buf_is_loaded(self.bufnr) then
         return true
       end
 
-      -- append
-      for i = old_lastline, new_lastline - 1 do
-        table.insert(self.words, i + 1, {})
+      local delta = new_last_line - old_last_line
+      local new_lines_count = self.lines_count + delta
+      if delta > 0 then -- append
+        -- Explicitly reserve more slots in the array part of the lines table,
+        -- all of them will be filled in the next loop, but in reverse order
+        -- (which is why I am concerned about preallocation). Why is there no
+        -- built-in function to do this in Lua???
+        for i = self.lines_count + 1, new_lines_count do
+          self.lines_words[i] = shared_marker_table_for_preallocation
+        end
+        -- Move forwards the unchanged elements in the tail part.
+        for i = self.lines_count, old_last_line + 1, -1 do
+          self.lines_words[i + delta] = self.lines_words[i]
+        end
+        -- Fill in new tables for the added lines.
+        for i = old_last_line + 1, new_last_line do
+          self.lines_words[i] = {}
+        end
+      elseif delta < 0 then -- remove
+        -- Move backwards the unchanged elements in the tail part.
+        for i = old_last_line + 1, self.lines_count do
+          self.lines_words[i + delta] = self.lines_words[i]
+        end
+        -- Remove (already copied) tables from the end, in reverse order, so
+        -- that we don't make holes in the lines table.
+        for i = self.lines_count, new_lines_count + 1, -1 do
+          self.lines_words[i] = nil
+        end
       end
-
-      -- remove
-      for _ = new_lastline, old_lastline - 1 do
-        table.remove(self.words, new_lastline + 1)
-      end
+      self.lines_count = new_lines_count
 
       -- replace lines
-      local lines = vim.api.nvim_buf_get_lines(self.bufnr, firstline, new_lastline, false)
+      local lines = vim.api.nvim_buf_get_lines(self.bufnr, first_line, new_last_line, true)
       vim.api.nvim_buf_call(self.bufnr, function()
         for i, line in ipairs(lines) do
-          if line then
-            self:index_line(firstline + i, line or '')
-          end
+          self:index_line(first_line + i, line)
         end
       end)
-    end),
+
+      self.unique_words_dirty = true
+    end,
+
+    on_detach = function(_)
+      self:close()
+    end,
   })
 end
 
 --- add_words
-function buffer.index_line(self, i, line)
-  local words = {}
+---@param linenr number
+---@param line string
+function buffer.index_line(self, linenr, line)
+  local words = self.lines_words[linenr]
+  for k, _ in ipairs(words) do
+    words[k] = nil
+  end
+  local word_i = 1
 
-  local buf = line
-  while true do
-    local s, e = self:matchstrpos(buf)
-    if s then
-      local word = string.sub(buf, s, e - 1)
+  local remaining = line
+  while #remaining > 0 do
+    -- NOTE: Both start and end indexes here are 0-based (unlike Lua strings),
+    -- and the end index is not inclusive.
+    local match_start, match_end = self.regex:match_str(remaining)
+    if match_start and match_end then
+      local word = remaining:sub(match_start + 1, match_end)
       if #word >= self.length then
-        table.insert(words, word)
+        words[word_i] = word
+        word_i = word_i + 1
       end
-    end
-    local new_buffer = string.sub(buf, e and e + 1 or 2)
-    if buf == new_buffer then
+      remaining = remaining:sub(match_end + 1)
+    else
       break
     end
-    buf = new_buffer
   end
-
-  self.words[i] = words
 end
 
 --- get_words
 function buffer.get_words(self)
-  local words = {}
-  for _, line in ipairs(self.words) do
+  -- NOTE: unique_words are rebuilt on-demand because it is common for the
+  -- watcher callback to be fired VERY frequently, and a rebuild needs to go
+  -- over ALL lines, not just the changed ones.
+  if self.unique_words_dirty then
+    self:rebuild_unique_words()
+  end
+  return self.unique_words
+end
+
+--- rebuild_unique_words
+function buffer.rebuild_unique_words(self)
+  for w, _ in pairs(self.unique_words) do
+    self.unique_words[w] = nil
+  end
+  for _, line in ipairs(self.lines_words) do
     for _, w in ipairs(line) do
-      table.insert(words, w)
+      self.unique_words[w] = true
     end
   end
-  return words
-end
-
---- matchstrpos
-function buffer.matchstrpos(self, text)
-  local s, e = self:regex(self.pattern):match_str(text)
-  if s == nil then
-    return nil, nil
-  end
-  return s + 1, e + 1
-end
-
---- regex
-function buffer.regex(self, pattern)
-  self.regexes[pattern] = self.regexes[pattern] or vim.regex(pattern)
-  return self.regexes[pattern]
+  self.unique_words_dirty = false
 end
 
 return buffer

--- a/lua/cmp_buffer/init.lua
+++ b/lua/cmp_buffer/init.lua
@@ -1,5 +1,13 @@
 local buffer = require('cmp_buffer.buffer')
 
+---@class cmp_buffer.Options
+---@field public keyword_length number
+---@field public keyword_pattern string
+---@field public get_bufnrs fun(): number[]
+---@field public indexing_chunk_size number
+---@field public indexing_interval number
+
+---@type cmp_buffer.Options
 local defaults = {
   keyword_length = 3,
   keyword_pattern = [[\%(-\?\d\+\%(\.\d\+\)\?\|\h\w*\%([\-]\w*\)*\)]],
@@ -18,27 +26,29 @@ source.new = function()
   return self
 end
 
+---@return cmp_buffer.Options
 source._validate_options = function(_, params)
-  params.option = vim.tbl_deep_extend('keep', params.option, defaults)
+  local opts = vim.tbl_deep_extend('keep', params.option, defaults)
   vim.validate({
-    keyword_length = { params.option.keyword_length, 'number' },
-    keyword_pattern = { params.option.keyword_pattern, 'string' },
-    get_bufnrs = { params.option.get_bufnrs, 'function' },
-    indexing_chunk_size = { params.option.indexing_chunk_size, 'number' },
-    indexing_interval = { params.option.indexing_interval, 'number' },
+    keyword_length = { opts.keyword_length, 'number' },
+    keyword_pattern = { opts.keyword_pattern, 'string' },
+    get_bufnrs = { opts.get_bufnrs, 'function' },
+    indexing_chunk_size = { opts.indexing_chunk_size, 'number' },
+    indexing_interval = { opts.indexing_interval, 'number' },
   })
+  return opts
 end
 
 source.get_keyword_pattern = function(self, params)
-  self:_validate_options(params)
-  return params.option.keyword_pattern
+  local opts = self:_validate_options(params)
+  return opts.keyword_pattern
 end
 
 source.complete = function(self, params, callback)
-  self:_validate_options(params)
+  local opts = self:_validate_options(params)
 
   local processing = false
-  local bufs = self:_get_buffers(params)
+  local bufs = self:_get_buffers(opts)
   for _, buf in ipairs(bufs) do
     if buf.timer then
       processing = true
@@ -71,18 +81,12 @@ source.complete = function(self, params, callback)
   end, processing and 100 or 0)
 end
 
---- _get_bufs
-source._get_buffers = function(self, params)
+---@param opts cmp_buffer.Options
+source._get_buffers = function(self, opts)
   local buffers = {}
-  for _, bufnr in ipairs(params.option.get_bufnrs()) do
+  for _, bufnr in ipairs(opts.get_bufnrs()) do
     if not self.buffers[bufnr] then
-      local new_buf = buffer.new(
-        bufnr,
-        params.option.keyword_length,
-        params.option.keyword_pattern,
-        params.option.indexing_chunk_size,
-        params.option.indexing_interval
-      )
+      local new_buf = buffer.new(bufnr, opts)
       new_buf.on_close_cb = function()
         self.buffers[bufnr] = nil
       end

--- a/lua/cmp_buffer/init.lua
+++ b/lua/cmp_buffer/init.lua
@@ -51,13 +51,15 @@ source.complete = function(self, params, callback)
     local items = {}
     local words = {}
     for _, buf in ipairs(bufs) do
-      for word, _ in pairs(buf:get_words()) do
-        if not words[word] and input ~= word then
-          words[word] = true
-          table.insert(items, {
-            label = word,
-            dup = 0,
-          })
+      for _, word_list in ipairs(buf:get_words()) do
+        for word, _ in pairs(word_list) do
+          if not words[word] and input ~= word then
+            words[word] = true
+            table.insert(items, {
+              label = word,
+              dup = 0,
+            })
+          end
         end
       end
     end

--- a/lua/cmp_buffer/init.lua
+++ b/lua/cmp_buffer/init.lua
@@ -40,7 +40,10 @@ source.complete = function(self, params, callback)
   local processing = false
   local bufs = self:_get_buffers(params)
   for _, buf in ipairs(bufs) do
-    processing = processing or buf.processing
+    if buf.timer then
+      processing = true
+      break
+    end
   end
 
   vim.defer_fn(function()
@@ -78,6 +81,9 @@ source._get_buffers = function(self, params)
         params.option.indexing_chunk_size,
         params.option.indexing_interval
       )
+      new_buf.on_close_cb = function()
+        self.buffers[bufnr] = nil
+      end
       new_buf:index()
       new_buf:watch()
       self.buffers[bufnr] = new_buf


### PR DESCRIPTION
(Ok, the title might sound funny because files of a few megabytes in size are considered large in 2021 when the RAM amounts of our computers are measured in gigabytes, but still, that's no reason not to optimize...)

This PR is pretty long, I know, but it contains a few intertwined optimizations, so I thought it would make sense to apply them all together. Here is a list of all stuff that I have done:

1. So first of all, I applied the general LuaJIT recommendations, such as avoiding `table.insert` for appending to lists and instead using a counter, not calculating the lengths of tables and storing their lengths instead, and, of course, recycling and clearing existing tables instead of allocating new ones as often as possible.

2. Instead of storing a table of compiled regexes in each instance of Buffer, I just compile the regex once in the constructor. AFAIK compilation should be independent of the editor state (with the exception of the `regexpengine` option, definitely), unlike evaluation, which is why I added `buf_call`s in my previous PR. Because a cache of regexes was stored separately in each Buffer, it would only contain a single item, which would have to be created almost immediately after construction in the `index_line` method anyway.

3. Speaking of `index_line`, I didn't record a proper profile, but I feel like evaluation of regexes takes roughly 90% of the whole time spent on indexing. This is really hard to optimize because most of the work is spent in Vim's regex engine and not in Lua where we have control. One cool optimization I imagined is offloading indexing to an entire separate thread with `vim.loop.new_work`, but that won't work because a) I doubt that Vim's regex engine is thread-safe and so this would explode and segfault; b) we need to call `nvim_buf_call`, which is definitely not thread-safe. I can imagine just re-implementing some simple specific regex with Lua code, for instance, `\k\+` (or adding a special case for this regex), which would require re-implementing `iskeyword` (the most interesting parts are [`buf_init_chartab`](https://github.com/neovim/neovim/blob/v0.5.0/src/nvim/charset.c#L83-L262) and [`vim_iswordc_tab`](https://github.com/neovim/neovim/blob/v0.5.0/src/nvim/charset.c#L831-L843) in `charset.c`, and the handling of non-ASCII characters ([`utf_class_tab`](https://github.com/neovim/neovim/blob/v0.5.0/src/nvim/mbyte.c#L1069-L1182) in `mbyte.c`, yeah...), and, in fact, this is [what coc.nvim does](https://github.com/neoclide/coc.nvim/blob/03c9add7cd867a013102dcb45fb4e75304d227d7/src/model/chars.ts) (although their implementation is incomplete, e.g. it doesn't try to do any special handling of Unicode characters and just considers all of them word chars).

   However, I believe that the ability to set a custom regex for recognizing words is a very convenient feature of this plugin, so let's leave it as it is. Anyway, there is still one way of optimizing `index_line` left - simply reduce the number of regex invocations. I don't know if this was intended, but the previous implementation had an inefficiency in it: when no match is found, it would advance character-by-character and retry the regex every time, instead of just skipping further processing of the line. Fixing this helped a little bit in reducing the run time (). Also, the previous implementation would skip 1 character after the match, which resulted in loss of some words (I have actually tested this by dumping the lists of indexed words).

4. Alright, now, for the main optimization related to RAM usage. I've added a "synchronous" indexing mode which takes advantage of some weird garbage collector behavior, and so **it improves memory usage by a factor of 2!!!** (I'll show results later) You may be worried by the fact that it is synchronous, however, on my machine at least it can process a 9 megabyte file in 1.5 seconds, so I believe that memory usage reduction is worth it. The trick that I use here is requesting buffer contents with multiple consequent `nvim_buf_get_lines` requests. I measured the overhead of making many many API calls here, in our case it is negligible in comparison to the time taken matching the regexes, so it's fine. I have also added options (with documentation) for controlling the speed of indexing and switching between the sync and async algorithms.

5. The deduplicated words are also cached. They are not updated right away in the watch callback, but rather on demand, when the `get_words` method sees that the lines have been modified by checking a "dirty" flag, because the `on_lines` event is invoked VERY frequently, and we don't want to block it with useless repeated work. Deduplication is not that fast, tens of milliseconds on 5-10 megabyte files, but the thing is that nvim-cmp calls the `complete` method of the source only once (on the first keystroke), so by itself this optimization will only save time if you, for example, trigger the popup menu, then close it, then open it again.

   However, the technique can be used in other ways, for instance: because completion is used only in the Insert mode and 99% of Insert editing in Vim happens on just the current line, the unique word table can be split in three parts: the current line, lines before it and lines after it, each with its own "dirty" flag. Then, the `on_lines` event will check if `first_line == current_line and first_line == new_last_line + 1 and old_last_line == new_last_line`, which would mean that only the current line has been changed, and only set the flag of the current line words table in that case. In general, this whole optimization is still effective even considering that we have to deduplicate words across multiple buffers (when the `get_bufnrs` option returns multiple IDs) because at this stage we are looping through hundreds of thousands of words.

6. Last but not least: I have rewritten the loops which append and delete lines in the `on_lines` event listener. See, the way it was written with Lua's built-in functions, which can only delete or insert one element at a time, meant that those loops had effectively O(n^2) complexity, which could very trivially result in huge lags when, for example, deleting the whole buffer contents with `ggdG`. You would think that clearing out the buffer would happen instantaneously because we only need to unload a bunch of strings from memory and there is nothing left to index, but no, the previous implementation would hang because of the quadratic time usage. I rewrote them to delete or move all elements in one loop, so this should not be a problem anymore. And also, I added the missing event handlers for `on_reload` (an easy way of triggering a reload: `:!touch %`) and `on_detach`, the last one is necessary to unload the indexes of closed buffers, so it kind of counts as a RAM optimization as well?

And now, the results. I'm going to use a compiled file from the Typescript repository, <https://github.com/microsoft/TypeScript/blob/v4.4.3/lib/tsserver.js>. It is perfect for the test because it is 10 megabytes big, is not minified (you will see why it is important later), and can be easily downloaded. However, for the purposes of the benchmark, I apply the following patch to the original code of this source:

```diff
diff --git a/lua/cmp_buffer/buffer.lua b/lua/cmp_buffer/buffer.lua
index 4ba7149..9fa86ef 100644
--- a/lua/cmp_buffer/buffer.lua
+++ b/lua/cmp_buffer/buffer.lua
@@ -42,7 +42,7 @@ function buffer.index(self)
     0,
     200,
     vim.schedule_wrap(function()
-      local chunk = math.min(index + 1000, #lines)
+      local chunk = #lines
       vim.api.nvim_buf_call(self.bufnr, function()
         for i = index, chunk do
           self:index_line(i, lines[i] or '')
```

Yes, it will turn the original asynchronous algorithm into a synchronous one because all will be lines indexed in one loop, but I think this doesn't matter and the comparison is still fair because we are not tricking the garbage collector here by running `nvim_buf_get_lines` multiple times, so how the memory is allocated won't change, and we will skip the pauses between indexing steps, so the CPU will be 100% loaded. I am going to measure performance with:

```lua
function _G._nvim_cmp_buffer_benchmark()
  local cmp_core = require('cmp.core')
  local source = cmp_core.sources_by_name['buffer'][1]
  local start_mem = vim.loop.resident_set_memory()
  local start_time = vim.loop.hrtime()
  source.source:complete({
    option = source:get_config().opts,
    context = { cursor_before_line = '' },
    offset = 1,
  }, function(result)
    local end_time = vim.loop.hrtime()
    local end_mem = vim.loop.resident_set_memory()
    print(
      string.format(
        '%d items, %f ms, %f MB',
        #result.items, -- For proof that everything works as before
        (end_time - start_time) / 1e6,
        (end_mem - start_mem) / 1024 / 1024
      )
    )
  end)
end
vim.cmd([[ autocmd VimEnter * lua vim.schedule(_G._nvim_cmp_buffer_benchmark) ]])
```

Let's go! The original version (5dde5430757696be4169ad409210cf5088554ed6):

```
run #1: 36667 items, 2069.154921 ms, 70.953125 MB
run #2: 36667 items, 2071.531198 ms, 70.949219 MB
run #3: 36667 items, 2047.786888 ms, 73.046875 MB
run #4: 36667 items, 2124.546513 ms, 70.917969 MB
run #5: 36667 items, 2058.463669 ms, 73.035156 MB
   avg:              2074.296638 ms, 71.780469 MB
```

Optimized version (b1fa2cb1dd71af0f072b7d2fa73ade3a7efdf01d), async mode (I am setting `indexing_chunk_size = 1e10` to get the same behavior as the patch shown above, therefore `indexing_interval` doesn't matter):

```
run #1: 36667 items, 1417.362432 ms, 68.656250 MB
run #2: 36667 items, 1420.224233 ms, 69.257812 MB
run #3: 36667 items, 1393.939492 ms, 68.683594 MB
run #4: 36667 items, 1402.539505 ms, 68.679688 MB
run #5: 36667 items, 1429.598909 ms, 69.207031 MB
   avg:              1412.732914 ms, 68.896875 MB
```

Optimized version (b1fa2cb1dd71af0f072b7d2fa73ade3a7efdf01d), sync mode (`indexing_interval = -1`):

```
run #1: 36667 items, 1424.161060 ms, 38.667969 MB
run #2: 36667 items, 1439.539344 ms, 35.007812 MB
run #3: 36667 items, 1448.200662 ms, 34.949219 MB
run #4: 36667 items, 1411.546087 ms, 38.914062 MB
run #5: 36667 items, 1406.199709 ms, 39.417969 MB
   avg:              1425.929372 ms, 37.391406 MB
```

Great! However, there are still two major performance problems left. First of all, `index_line` blows up on files with long lines. Why? You see, when we slice a string with `string.sub`, this function creates a copy of the slice, and this results in catastrophic memory usage on files with very long lines where very very long slices of the remaining part of the string are created after each match while running `index_line`, which just crashes Vim with a "not enough memory" error on my computer. The Vimscript `matchstrpos` function avoids this problem - it has a `start` parameter, so that we can start at any index we want without having to create and allocate a slice of the string starting at that index. But it is not available in Lua's `vim.regex.match_str`! This can only be solved by making a patch to Neovim: the [internal C function](https://github.com/neovim/neovim/blob/v0.5.0/src/nvim/regexp.c#L7387-L7392) ([documentation here](https://github.com/neovim/neovim/blob/v0.5.0/src/nvim/regexp.c#L7308-L7321)) for evaluating a regex actually has a parameter for the byte position at which to start searching, they just forgot to add to in the [Lua interface](https://github.com/neovim/neovim/blob/v0.5.0/src/nvim/lua/executor.c#L1601). Alternatively, we can just call the Vimscript function, which makes the indexing considerably slower (2517.396650 ms and 43.835938 MB on the file in the benchmarks) and recompiles the regex every time:

```lua
function buffer.index_line(self, linenr, line)
  -- ...
  local idx = 0
  local line_len = #line
  local matchstrpos = vim.fn.matchstrpos
  while idx < line_len do
    local word, match_start, match_end = unpack(matchstrpos(line, self.pattern, idx), 1, 3)
    if match_start >= 0 and match_end >= 0 then
      if #word > 1 then
        words[word_i] = word
        word_i = word_i + 1
      end
      idx = match_end
    else
      break
    end
  end
end
```

The other issue is, well, that nvim-cmp doesn't like when tens of thousands of unique words are being thrown at it. Again, taking the file from the benchmark, if I just open the editor with `tsserver.js`, it will take 35 megabytes of RAM, if I then run the indexer, it will consume 35 more, but just pressing `<Ctrl-Space>`, which triggers the completion menu, makes Vim eat 180 megabytes! I believe it is because of the need to create 37 thousand `cmp.Entry`ies, and I can't really blame nvim-cmp for that. The number of completion items definitely must be reduced, but I don't know what is the best way to do that. I can come up with two solutions (they can be implemented together):

1. An option like `word_min_occurrences` which would allow filtering out rare words which occur in the file just 1-2 times (but will probably make the user experience worse on typical, "small", code files).
2. Another option like `max_top_words` which would only show, for example, the top 1000 words in the completion results sorted by the number of their usages.

Both should be easy to do - we already have a table of unique words, and instead of setting `true` we can use each value as a counter. I addressed the problem of _indexing_ large files, but I believe that finding an answer to this particular question (reduction of the number of completion items) will help with improving the user experience of _editing_ large files.