### PR TITLE
docs: fix sources[n].option -> options

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ cmp.setup({
   sources = {
     { 
       name = 'buffer',
-      option = {
+      options = {
         -- Options go into this table
       },
     },
@@ -55,7 +55,7 @@ cmp.setup({
     {
       name = 'buffer',
       -- Correct:
-      option = {
+      options = {
         keyword_pattern = [[\k\+]],
       }
     },


### PR DESCRIPTION
@hrsh7th Isn't it `options` rather than `option`?