### PR TITLE
Add a note that set hidden is necessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ _Default:_ `function() return { vim.api.nvim_get_current_buf() } end`
 
 A function that specifies the buffer numbers to complete.
 
+**NOTE:** If using this, make sure you have `set hidden`, otherwise it will not work correctly.
+
 You can use the following pre-defined recipes.
 
 ##### All buffers


### PR DESCRIPTION
I already opened #58 for this, but then I thought I may as well open a PR with a simple suggestion.

Long story short is: multiple buffers don't work well when `set nohidden`. It seems tricky to modify the code to make it work, but at least documenting that is necessary can save somebody an hour of debugging :)