### PR TITLE
Add option to suggest words in different cases

### DIFF
--- a/lua/cmp_buffer/cases.lua
+++ b/lua/cmp_buffer/cases.lua
@@ -1,0 +1,113 @@
+function get_word_slices(name)
+  local slices = {}
+  local current_word = ""
+  local last_character_uppercase = true
+
+  for i = 1, #name do
+    local character = name:sub(i, i)
+
+    if character == "_" or character == "-" then
+      if current_word ~= "" then
+        table.insert(slices, current_word)
+        current_word = ""
+      end
+
+      last_character_uppercase = false
+    elseif string.upper(character) == character then
+
+      if last_character_uppercase or current_word == "" then
+        current_word = current_word .. string.lower(character)
+      else
+        table.insert(slices, current_word)
+        current_word = string.lower(character)
+      end
+
+      last_character_uppercase = true
+    else
+      current_word = current_word .. character
+      last_character_uppercase = false
+    end
+  end
+
+  if current_word ~= "" then
+    table.insert(slices, current_word)
+  end
+
+  return slices
+end
+
+function snake_case(slices)
+  local word = ""
+
+  for index, slice in ipairs(slices) do
+    if index > 1 then
+      word = word .. "_"
+    end
+
+    word = word .. slice
+  end
+
+  return word
+end
+
+function kebab_case(slices)
+  local word = ""
+
+  for index, slice in ipairs(slices) do
+    if index > 1 then
+      word = word .. "-"
+    end
+
+    word = word .. slice
+  end
+
+  return word
+end
+
+function camel_case(slices)
+  local word = ""
+
+  for index, slice in ipairs(slices) do
+    if index == 1 then
+      word = word .. slice
+    else
+      word = word .. string.upper(string.sub(slice, 1, 1))
+      word = word .. string.sub(slice, 2, -1)
+    end
+  end
+
+  return word
+end
+
+function pascal_case(slices)
+  local word = ""
+
+  for _, slice in ipairs(slices) do
+    word = word .. string.upper(string.sub(slice, 1, 1))
+    word = word .. string.sub(slice, 2, -1)
+  end
+
+  return word
+end
+
+function macro_case(slices)
+  local word = ""
+
+  for index, slice in ipairs(slices) do
+    if index > 1 then
+      word = word .. "_"
+    end
+
+    word = word .. string.upper(slice)
+  end
+
+  return word
+end
+
+return {
+  ["snake"] = snake_case,
+  ["camel"] = camel_case,
+  ["pascal"] = pascal_case,
+  ["kebab"] = kebab_case,
+  ["macro"] = macro_case,
+}

--- a/lua/cmp_buffer/cases.lua
+++ b/lua/cmp_buffer/cases.lua
@@ -1,3 +1,4 @@
+-- slice a word to individual slices. "my_cool_word" -> { "my", "cool", "word" }
 function get_word_slices(name)
   local slices = {}
   local current_word = ""
@@ -36,6 +37,7 @@ function get_word_slices(name)
   return slices
 end
 
+-- e.g. my_cool_word
 function snake_case(slices)
   local word = ""
 
@@ -50,6 +52,7 @@ function snake_case(slices)
   return word
 end
 
+-- e.g. my-cool-word
 function kebab_case(slices)
   local word = ""
 
@@ -64,6 +67,7 @@ function kebab_case(slices)
   return word
 end
 
+-- e.g. myCoolWord
 function camel_case(slices)
   local word = ""
 
@@ -79,6 +83,7 @@ function camel_case(slices)
   return word
 end
 
+-- e.g. MyCoolWord
 function pascal_case(slices)
   local word = ""
 
@@ -90,6 +95,7 @@ function pascal_case(slices)
   return word
 end
 
+-- e.g. MY_COOL_WORD
 function macro_case(slices)
   local word = ""
 
@@ -104,6 +110,7 @@ function macro_case(slices)
   return word
 end
 
+-- lookup table for all cases that are suppored out of the box
 return {
   ["snake"] = snake_case,
   ["camel"] = camel_case,


### PR DESCRIPTION
This is a feature I wanted for a long time and after posting my fork on Reddit many people have expressed their interest in having this feature upstream.

The design right now is that you can add this to your options `cases = { "snake", "pascal" }` to get suggestions of the words in your buffer in those cases. Out of the box I implemented `snake case`, `camel case`, `pascal case`, `kebab case`, and `macro case`. Users can also provide functions that take a sequence of strings and return a string to add custom cases.

Here is a screenshot of it working as intended:
![suggestions_working](https://user-images.githubusercontent.com/24727270/211439832-91c78813-ebe1-40a2-bf7b-0d4d96954c44.png)

I am relatively new to vim plugins so I was unsure about things like error messages and validation. For example, if the user specifies an incorrect case or provides a function that does not return a string there is currently no error message, it will simply not show the suggestion. If that is desirable I can add extra validation in those places.