### PR TITLE
Keyword pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The number of characters that need to be typed to trigger auto-completion.
 
 ### keyword_pattern (type: string)
 
-_Default:_ `[[\%(-\?\d\+\%(\.\d\+\)\?\|\h\w*\%([\-.]\w*\)*\)]]`
+_Default:_ `[[\%(-\?\d\+\%(\.\d\+\)\?\|\%(\h\|[\u00C0-\u00D6]\|[\u00D8-\u00F6]\|[\u00F8-\u02AF]\)\%(\w\|[\u00C0-\u00D6]\|[\u00D8-\u00F6]\|[\u00F8-\u02AF]\)*\%(-\%(\w\|[\u00C0-\u00D6]\|[\u00D8-\u00F6]\|[\u00F8-\u02AF]\)*\)*\)]]`
 
 A vim's regular expression for creating a word list from buffer content.
 

--- a/lua/cmp_buffer/source.lua
+++ b/lua/cmp_buffer/source.lua
@@ -11,7 +11,7 @@ local buffer = require('cmp_buffer.buffer')
 ---@type cmp_buffer.Options
 local defaults = {
   keyword_length = 3,
-  keyword_pattern = [[\%(-\?\d\+\%(\.\d\+\)\?\|\h\%(\w\|á\|Á\|é\|É\|í\|Í\|ó\|Ó\|ú\|Ú\)*\%(-\%(\w\|á\|Á\|é\|É\|í\|Í\|ó\|Ó\|ú\|Ú\)*\)*\)]],
+  keyword_pattern = [[\%(-\?\d\+\%(\.\d\+\)\?\|\%(\h\|[\u00C0-\u00D6]\|[\u00D8-\u00F6]\|[\u00F8-\u02AF]\)\%(\w\|[\u00C0-\u00D6]\|[\u00D8-\u00F6]\|[\u00F8-\u02AF]\)*\%(-\%(\w\|[\u00C0-\u00D6]\|[\u00D8-\u00F6]\|[\u00F8-\u02AF]\)*\)*\)]],
   get_bufnrs = function()
     return { vim.api.nvim_get_current_buf() }
   end,


### PR DESCRIPTION
Before, the keyword pattern only accepted words with letters `[A-Za-z]` and vowels with acute accents (only in the middle/end of the word, not at the beggining, due to how `\h` works).

This behaviour doesn't accept other languages written in latin alphabet, such as spanish (needs to accept ñ), or french (needs to accept ç, vowels with different kinds of accents).

This solution isn't ideal, as I think it ends up accepting more characters than needed (and also looking quite ugly), but I tested it and I don't notice any downside in its use.