### PR TITLE
Add `show_source` option to show the source buffer

### DIFF
--- a/lua/cmp_buffer/buffer.lua
+++ b/lua/cmp_buffer/buffer.lua
@@ -377,4 +377,16 @@ function buffer.get_words_distances(self, cursor_row)
   return self.words_distances
 end
 
+--@return name of buffer (maybe shortened), if file, otherwise buffer number
+function buffer.description(self, short)
+  local name = vim.fn.bufname(self.bufnr)
+  if name then
+    if short then
+      return name:match("[^/]*$")
+    end
+    return name
+  end
+  return ("<buf %d>"):format(self.bufnr)
+end
+
 return buffer

--- a/lua/cmp_buffer/source.lua
+++ b/lua/cmp_buffer/source.lua
@@ -7,6 +7,7 @@ local buffer = require('cmp_buffer.buffer')
 ---@field public indexing_batch_size number
 ---@field public indexing_interval number
 ---@field public max_indexed_line_length number
+---@field public show_source boolean
 
 ---@type cmp_buffer.Options
 local defaults = {
@@ -18,6 +19,7 @@ local defaults = {
   indexing_batch_size = 1000,
   indexing_interval = 100,
   max_indexed_line_length = 1024 * 40,
+  show_source = false,
 }
 
 local source = {}
@@ -37,6 +39,7 @@ source._validate_options = function(_, params)
     get_bufnrs = { opts.get_bufnrs, 'function' },
     indexing_batch_size = { opts.indexing_batch_size, 'number' },
     indexing_interval = { opts.indexing_interval, 'number' },
+    show_source = { opts.show_source, 'boolean' },
   })
   return opts
 end
@@ -70,6 +73,10 @@ source.complete = function(self, params, callback)
             table.insert(items, {
               label = word,
               dup = 0,
+              labelDetails = opts.show_source and {
+                description = buf:description(true),
+              },
+              detail = opts.show_source and buf:description(),
             })
           end
         end


### PR DESCRIPTION
This adds a `show_source` option, which, if given, will return the buffer name of a given match, to allow it to be shown to the user when completing.

The output looks like:
![image](https://github.com/hrsh7th/cmp-buffer/assets/205673/ee6cbe49-bdd6-45a8-96aa-97d23b79373e)
